### PR TITLE
Changing python-pbr version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pbr>=0.6,!=0.7,<1.0
+pbr>=1.6
 
 Paste
 PasteDeploy>=1.5.0


### PR DESCRIPTION
When using with the stable/mitaka, pbr version conflicts from other openstack components and tacker SFC_colorado. Hence changing the pbr version to 1.6. 