### PR TITLE
Add keystone v3 compatibility to trozet/tacker

### DIFF
--- a/tacker/common/utils.py
+++ b/tacker/common/utils.py
@@ -25,6 +25,7 @@ import logging as std_logging
 import multiprocessing
 import os
 import random
+import re
 import signal
 import socket
 import uuid
@@ -299,3 +300,13 @@ def cpu_count():
         return multiprocessing.cpu_count()
     except NotImplementedError:
         return 1
+
+
+def is_auth_uri_v3(auth_url):
+    return (re.match('.+v3/?$', auth_url) is not None)
+
+
+def format_auth_uri_version(auth_url):
+    if re.match('.+(v3/?|v2\.0/?)$', auth_url) is None:
+        auth_url = '{0}/v2.0'.format(auth_url)
+    return auth_url

--- a/tacker/sfc/plugin.py
+++ b/tacker/sfc/plugin.py
@@ -27,6 +27,7 @@ from sqlalchemy.orm import exc as orm_exc
 
 from tacker.api.v1 import attributes
 from tacker.common import driver_manager
+from tacker.common import utils as common_utils
 from tacker import context as t_context
 from tacker.db.sfc import sfc_db
 from tacker.extensions import sfc
@@ -196,7 +197,8 @@ class SFCPlugin(sfc_db.SFCPluginDb):
 
 class NeutronClient:
     def __init__(self):
-        auth_url = cfg.CONF.keystone_authtoken.auth_uri
+        auth_url = common_utils.format_auth_uri_version(
+            cfg.CONF.keystone_authtoken.auth_uri)
         authtoken = cfg.CONF.keystone_authtoken
         kwargs = {
             'password': authtoken.password,

--- a/tacker/tests/functional/vnfd/base.py
+++ b/tacker/tests/functional/vnfd/base.py
@@ -12,12 +12,14 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import re
 import time
 
 from oslo_config import cfg
 from tempest_lib.tests import base
 
 from tacker import version
+from tacker.common import utils as common_utils
 from tackerclient.v1_0 import client as tacker_client
 
 CONF = cfg.CONF
@@ -58,7 +60,9 @@ class BaseTackerTest(base.TestCase):
         username = cfg.CONF.keystone_authtoken.username
         password = cfg.CONF.keystone_authtoken.password
         tenant_name = cfg.CONF.keystone_authtoken.project_name
-        auth_uri = cfg.CONF.keystone_authtoken.auth_uri + '/v2.0'
+        auth_uri = common_utils.format_auth_uri_version(
+            cfg.CONF.keystone_authtoken.auth_uri)
+
         return tacker_client.Client(username=username, password=password,
                                  tenant_name=tenant_name,
                                  auth_url=auth_uri)

--- a/tacker/vm/drivers/heat/heat.py
+++ b/tacker/vm/drivers/heat/heat.py
@@ -27,14 +27,20 @@ import yaml
 
 from heatclient import client as heat_client
 from heatclient import exc as heatException
-from keystoneclient.v2_0 import client as ks_client
+
 from oslo_config import cfg
 
 from tacker.common import log
+from tacker.common import utils as common_utils
 from tacker.extensions import vnfm
 from tacker.openstack.common import jsonutils
 from tacker.openstack.common import log as logging
 from tacker.vm.drivers import abstract_driver
+
+if common_utils.is_auth_uri_v3(cfg.CONF.keystone_authtoken.auth_uri):
+    from keystoneclient.v3 import client as ks_client
+else:
+    from keystoneclient.v2_0 import client as ks_client
 
 
 LOG = logging.getLogger(__name__)
@@ -451,7 +457,9 @@ class DeviceHeat(abstract_driver.DeviceAbstractDriver):
 class HeatClient:
     def __init__(self, context, password=None):
         # context, password are unused
-        auth_url = CONF.keystone_authtoken.auth_uri
+        auth_url = common_utils.format_auth_uri_version(
+            cfg.CONF.keystone_authtoken.auth_uri)
+
         authtoken = CONF.keystone_authtoken
         kc = ks_client.Client(
             tenant_name=authtoken.project_name,


### PR DESCRIPTION
Uplift to keystoneclient v3

Replace old v2.0 specific keystone related code with v3

Signed-off-by: George Paraskevopoulos <geopar@intracom-telecom.com>

Add keystoneclient v3 compatibility

As per the comments of trozet instead of uplifting we keep
keystoneclient v2.0 as the default and use keystoneclient v3 only when
OS_AUTH_URL ends with /v3

Signed-off-by: George Paraskevopoulos <geopar@intracom-telecom.com>

Match auth_uri trailing version correctly

Use a regex to match the auth_uri trailing version to ignore trailing
slashes.

Signed-off-by: George Paraskevopoulos <geopar@intracom-telecom.com>

Fix url version matching logic.

The version matching condition was inverted. This is fixed and all the
version matching logic was moved in tacker.common.utils

Signed-off-by: George Paraskevopoulos <geopar@intracom-telecom.com>

Move version formatting check into util function

Signed-off-by: George Paraskevopoulos <geopar@intracom-telecom.com>